### PR TITLE
 fix/#200-status-code-is-shown-when-a-book-with-empty-imagePath-is-posted-in-Swagger

### DIFF
--- a/src/users/dto/create-book.dto.ts
+++ b/src/users/dto/create-book.dto.ts
@@ -13,6 +13,7 @@ export class CreateBookDto {
   @ApiProperty({
     example: 'http://.......',
   })
+  @IsNotEmpty()
   @IsOptional()
   imagePath: string;
 

--- a/src/users/dto/update-book.dto.ts
+++ b/src/users/dto/update-book.dto.ts
@@ -15,6 +15,7 @@ export class UpdateBookDto {
   @ApiProperty({
     example: 'http://.......',
   })
+  @IsNotEmpty()
   @IsOptional()
   imagePath?: string;
 


### PR DESCRIPTION
add IsNotEmpty